### PR TITLE
Add options to specify contentType for translation and a replace function for translated text

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,24 @@ var ulisClient = new ulis.getClient({
 });
 
 ```
+
+Optionally, you can specify the format of the text being translated. The supported formats are `text/plain` (default) and `text/html`.
+It is also possible to execute a function on the translated text before it is sent to LUIS. This is especially helpful if you want to exclude content from translation, see http://docs.microsofttranslator.com/text-translate.html#excluding-content-from-translation.
+
+Example:
+
+```js
+var ulisClient = new ulis.getClient({
+    lang:'he',
+    bingTranslate_api_key:'TRANSLATE_API_KEY',
+    luisURL: 'LUIS_ENDPOINT',
+
+    // set the format
+    contentType: 'text/html',
+
+    // pass a function that is applied to the translated text and removes the HTML
+    // from text enclosed with <div class="notranslate">text<\/div>
+    replaceInTranslation: text => text.replace(/<div class="notranslate">(.*?)<\/div>/g, ' $1')
+});
+
+```

--- a/ulis/lib/ulis.js
+++ b/ulis/lib/ulis.js
@@ -58,7 +58,8 @@ function getClient(opts) {
 		var params = {
 			text: text,
 			from: lang,
-			to: 'en'
+			to: 'en',
+			contentType: opts.contentType ? opts.contentType : 'text/plain',
 		};
 
 		console.log(`Translating: ${text}`);
@@ -68,9 +69,14 @@ function getClient(opts) {
 				console.error(`Error translating: ${err.message}`);
 				return cb(err);
 			}
+
+			if (opts.replaceInTranslation) {
+				translation = opts.replaceInTranslation(translation);
+			}
+			
 			//write textToTranslate and translation to csv 
 			console.log(`Translating completed: ${text}:${translation}`);
-			return cb(null, translation);		
+			return cb(null, translation);
 		});
 		
 	}


### PR DESCRIPTION
I want to be able to pass text like

`What's up in <div class="notranslate">München<\/div>?`

to ULIS. To ensure that this text is processed correctly, the content type must be changed to text/html and the `<div class="notranslate">...<\/div>` HTML-part has to be removed from the translated text before sending it to LUIS. To make this possible, the two options `contentType` and `replaceInTranslation` can be specified during the setup of the ULIS client (see readme).